### PR TITLE
fix: manage nested field missing from data

### DIFF
--- a/rest_framework_friendly_errors/mixins.py
+++ b/rest_framework_friendly_errors/mixins.py
@@ -203,7 +203,7 @@ class FriendlyErrorMessagesMixin(FieldMap):
                     data))
             else:
                 field = fields[error_type]
-                if hasattr(field, 'fields'):
+                if hasattr(field, 'fields') and error_type in data:
                     pretty.append({
                         'field': 'client',
                         'errors': self.build_pretty_errors(


### PR DESCRIPTION
If there is a required nested field that is not present in the payload, it raises an error when you do `data['error_type']` (here : https://github.com/vamonte/drf-friendly-errors/blob/master/rest_framework_friendly_errors/mixins.py#L212)

I think this PR should fix it.
