### PR TITLE
Manage nested serializers for one to many relations

### DIFF
--- a/rest_framework_friendly_errors/mixins.py
+++ b/rest_framework_friendly_errors/mixins.py
@@ -211,6 +211,17 @@ class FriendlyErrorMessagesMixin(FieldMap):
                             fields[error_type].fields,
                             data[error_type])['errors'],
                     })
+                elif hasattr(field, 'child') and error_type in data:
+                    pretty.append({
+                        'field': error_type,
+                        'errors': [
+                            self.build_pretty_errors(
+                                e,
+                                field.child.fields.fields,
+                                data[error_type][i])['errors']
+                            for i, e in enumerate(errors[error_type])
+                        ],
+                    })
                 else:
                     pretty.extend(
                         self.get_field_error_entries(errors[error_type], field,


### PR DESCRIPTION
J'ai réalisé deux choses : 
- la lib n'était pas du complètement compatible avec les versions de Django et djangorestframework qu'on utilise ... malheureusement c'est pas retrocompatible mais je ne pense pas que tu aies l'intention de demander à merger ton fork (premier commit)
- quand on crée un validateur de champ dans un serializer, on peut spécifier qu'un seul code d'erreur (via l'attribut FIELD_VALIDATION_ERRORS) mais si on veut tester deux trucs sur un champ, on se retrouve à devoir utiliser le même code d'erreur, ce qui n'est pas pratique ... (deuxième commit)

Et troisième commit, gestion du cas des communities : un client a une liste de communities (on gérait les nested serializers mais que pour les cas de relations one to one, pas one to many comme pour les communities)

--> finalement seul le dernier commit dans cette PR